### PR TITLE
MMC1 Mapper

### DIFF
--- a/src/emulator/clock.rs
+++ b/src/emulator/clock.rs
@@ -25,12 +25,14 @@ impl ScaledTicker {
 }
 
 impl Ticker for ScaledTicker {
+    #[inline]
     fn tick(&mut self) -> u32 {
         self.delegate.tick() * self.factor
     }
 }
 
 impl <T : Ticker> Ticker for Rc<RefCell<T>> {
+    #[inline]
     fn tick(&mut self) -> u32 {
         self.borrow_mut().tick()
     }

--- a/src/emulator/clock.rs
+++ b/src/emulator/clock.rs
@@ -30,9 +30,7 @@ impl Ticker for ScaledTicker {
     }
 }
 
-pub type TickerRef = Rc<RefCell<dyn Ticker>>;
-
-impl Ticker for TickerRef {
+impl <T : Ticker> Ticker for Rc<RefCell<T>> {
     fn tick(&mut self) -> u32 {
         self.borrow_mut().tick()
     }
@@ -163,7 +161,7 @@ mod test {
     fn test_single_ticker() {
         let mut clock = Clock::new(0, 1);
         let ticker = Rc::new(RefCell::new(DummyTicker::new()));
-        clock.manage(ticker.clone());
+        clock.manage(Box::new(ticker.clone()));
 
         clock.tick();
         assert_eq!(ticker.borrow().value, 1);
@@ -178,10 +176,10 @@ mod test {
         let mut clock = Clock::new(0, 1);
         let ticker1 = Rc::new(RefCell::new(DummyTicker::new()));
         let ticker3 = Rc::new(RefCell::new(DummyTicker::new()));
-        let scaled_ticker3 = Rc::new(RefCell::new(ScaledTicker::new(ticker3.clone(), 3)));
+        let scaled_ticker3 = Rc::new(RefCell::new(ScaledTicker::new(Box::new(ticker3.clone()), 3)));
 
-        clock.manage(ticker1.clone());
-        clock.manage(scaled_ticker3.clone());
+        clock.manage(Box::new(ticker1.clone()));
+        clock.manage(Box::new(scaled_ticker3.clone()));
 
         // Tick twice first since the initial order is undefined.
         clock.tick();

--- a/src/emulator/cpu/mod.rs
+++ b/src/emulator/cpu/mod.rs
@@ -81,6 +81,7 @@ pub fn new(memory: Box<ReadWriter>) -> CPU {
 }
 
 impl clock::Ticker for CPU {
+    #[inline]
     fn tick(&mut self) -> u32 {
         return if self.should_non_maskable_interrupt() {
             self.nmi_flip_flop = false;

--- a/src/emulator/cpu/mod.rs
+++ b/src/emulator/cpu/mod.rs
@@ -427,7 +427,7 @@ impl CPU {
             opcodes::TSX => (instructions::tsx, addressing::implied, 2),
             opcodes::TXS => (instructions::txs, addressing::implied, 2),
 
-            _ => panic!("Unknown opcode: {:X}", opcode)
+            _ => panic!("Unknown opcode: {:X}", opcode),
         }
     }
 

--- a/src/emulator/cpu/mod.rs
+++ b/src/emulator/cpu/mod.rs
@@ -12,8 +12,7 @@ use std::io::Write;
 use emulator::clock;
 use emulator::components::bitfield::BitField;
 use emulator::memory;
-use emulator::memory::Reader;
-use emulator::memory::Writer;
+use emulator::memory::{Reader, Writer};
 use emulator::util;
 
 // Program vector locations.
@@ -39,7 +38,7 @@ impl Into<u8> for Flag {
 
 pub struct CPU {
     // Connection to main memory.
-    memory: memory::Manager,
+    memory: memory::MemoryRef,
 
     // Accumulator
     a: u8,
@@ -66,7 +65,7 @@ pub struct CPU {
     nmi_flip_flop: bool,
 }
 
-pub fn new(memory: memory::Manager) -> CPU {
+pub fn new(memory: memory::MemoryRef) -> CPU {
     let mut p = BitField::new();
     p.load_byte(0x00);
     CPU {

--- a/src/emulator/cpu/mod.rs
+++ b/src/emulator/cpu/mod.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 
 use emulator::clock;
 use emulator::components::bitfield::BitField;
-use emulator::memory::{Reader, ReadWriter, Writer};
+use emulator::memory::ReadWriter;
 use emulator::util;
 
 // Program vector locations.

--- a/src/emulator/cpu/mod.rs
+++ b/src/emulator/cpu/mod.rs
@@ -11,8 +11,7 @@ use std::io::Write;
 
 use emulator::clock;
 use emulator::components::bitfield::BitField;
-use emulator::memory;
-use emulator::memory::{Reader, Writer};
+use emulator::memory::{Reader, ReadWriter, Writer};
 use emulator::util;
 
 // Program vector locations.
@@ -38,7 +37,7 @@ impl Into<u8> for Flag {
 
 pub struct CPU {
     // Connection to main memory.
-    memory: memory::MemoryRef,
+    memory: Box<ReadWriter>,
 
     // Accumulator
     a: u8,
@@ -65,7 +64,7 @@ pub struct CPU {
     nmi_flip_flop: bool,
 }
 
-pub fn new(memory: memory::MemoryRef) -> CPU {
+pub fn new(memory: Box<ReadWriter>) -> CPU {
     let mut p = BitField::new();
     p.load_byte(0x00);
     CPU {

--- a/src/emulator/cpu/test/instructions_accumulator.rs
+++ b/src/emulator/cpu/test/instructions_accumulator.rs
@@ -4,8 +4,6 @@ use emulator::cpu::test::load_data;
 use emulator::cpu::test::new_cpu;
 use emulator::cpu::test::run_program;
 
-use emulator::memory::Reader;
-
 #[test]
 fn test_lda_sets_zero_flag() {
     let mut cpu = new_cpu();

--- a/src/emulator/cpu/test/instructions_index_registers.rs
+++ b/src/emulator/cpu/test/instructions_index_registers.rs
@@ -4,8 +4,6 @@ use emulator::cpu::test::load_data;
 use emulator::cpu::test::new_cpu;
 use emulator::cpu::test::run_program;
 
-use emulator::memory::Reader;
-
 #[test]
 fn test_ldx_immediate() {
     let mut cpu = new_cpu();

--- a/src/emulator/cpu/test/mod.rs
+++ b/src/emulator/cpu/test/mod.rs
@@ -11,9 +11,6 @@ mod nestest;
 mod programs;
 mod startup_interrupts;
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use emulator::cpu;
 use emulator::memory;
 use emulator::memory::ReadWriter;

--- a/src/emulator/cpu/test/mod.rs
+++ b/src/emulator/cpu/test/mod.rs
@@ -20,10 +20,10 @@ use emulator::memory::ReadWriter;
 
 pub const PROGRAM_ROOT: u16 = 0xF000;
 fn new_cpu() -> cpu::CPU {
-    cpu::new(Rc::new(RefCell::new(memory::RAM::new())))
+    cpu::new(Box::new(memory::RAM::new()))
 }
 
-fn load_data(memory: &mut ReadWriter, addr: u16, bytes: &[u8]) {
+fn load_data(memory: &mut Box<dyn ReadWriter>, addr: u16, bytes: &[u8]) {
     for (ix, byte) in bytes.iter().enumerate() {
         memory.write(addr + (ix as u16), *byte);
     }

--- a/src/emulator/cpu/test/mod.rs
+++ b/src/emulator/cpu/test/mod.rs
@@ -11,16 +11,19 @@ mod nestest;
 mod programs;
 mod startup_interrupts;
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use emulator::cpu;
 use emulator::memory;
-use emulator::memory::Writer;
+use emulator::memory::ReadWriter;
 
 pub const PROGRAM_ROOT: u16 = 0xF000;
 fn new_cpu() -> cpu::CPU {
-    cpu::new(memory::new())
+    cpu::new(Rc::new(RefCell::new(memory::RAM::new())))
 }
 
-fn load_data(memory: &mut memory::Manager, addr: u16, bytes: &[u8]) {
+fn load_data(memory: &mut ReadWriter, addr: u16, bytes: &[u8]) {
     for (ix, byte) in bytes.iter().enumerate() {
         memory.write(addr + (ix as u16), *byte);
     }

--- a/src/emulator/cpu/test/nestest.rs
+++ b/src/emulator/cpu/test/nestest.rs
@@ -6,10 +6,12 @@ use emulator::clock::Ticker;
 use emulator::cpu;
 use emulator::memory;
 
+use emulator::cpu::test::new_cpu;
+
 #[test]
 fn test_nestest() {
     println!("Hello, world!");
-    let mut cpu = cpu::new(memory::new());
+    let mut cpu = new_cpu();
     cpu.disable_bcd();
 
     load_rom(&mut cpu);

--- a/src/emulator/cpu/test/nestest.rs
+++ b/src/emulator/cpu/test/nestest.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 use emulator::clock::Ticker;
 use emulator::cpu;
-use emulator::memory;
 
 use emulator::cpu::test::new_cpu;
 

--- a/src/emulator/cpu/test/programs.rs
+++ b/src/emulator/cpu/test/programs.rs
@@ -4,8 +4,6 @@ use emulator::cpu::test::load_data;
 use emulator::cpu::test::new_cpu;
 use emulator::cpu::test::run_program;
 
-use emulator::memory::Reader;
-
 #[test]
 fn test_load_add_save() {
     let mut cpu = new_cpu();

--- a/src/emulator/ines.rs
+++ b/src/emulator/ines.rs
@@ -24,6 +24,10 @@ impl ROM {
         }
     }
 
+    pub fn mapper_number(&self) -> u8 {
+        ((self.data[6] & 0xF0) >> 4) | (self.data[7] & 0xF0)
+    }
+
     pub fn prg_rom(&self) -> &[u8] {
         let size = self.prg_rom_size_bytes();
         let start = 16 as usize;
@@ -31,19 +35,25 @@ impl ROM {
         &self.data[start..end]
     }
 
-    pub fn prg_rom_size_bytes(&self) -> u16 {
-        (self.data[4] as u16) * 16384
+    pub fn prg_rom_size_bytes(&self) -> u32 {
+        (self.data[4] as u32) * 16384
     }
 
     pub fn chr_rom(&self) -> &[u8] {
         let prg_size = self.prg_rom_size_bytes();
         let size = self.chr_rom_size_bytes();
-        let start = (16 + prg_size) as usize;
-        let end = start + size as usize;
-        &self.data[start..end]
+
+        if size == 0 {
+            // Cartridge uses chr_ram.
+            &[0; 0x2000]
+        } else {
+            let start = (16 + prg_size) as usize;
+            let end = start + size as usize;
+            &self.data[start..end]
+        }
     }
 
-    pub fn chr_rom_size_bytes(&self) -> u16 {
-        (self.data[5] as u16) * 8192
+    pub fn chr_rom_size_bytes(&self) -> u32 {
+        (self.data[5] as u32) * 8192
     }
 }

--- a/src/emulator/mappers.rs
+++ b/src/emulator/mappers.rs
@@ -177,7 +177,7 @@ impl memory::Mapper for MMC1 {
             self.load_register = 0;
             self.write_index = 0;
             self.update_offsets();
-            //println!("control: 0x{:X}, prg: 0x{:X}, chr1: 0x{:X}, chr2: 0x{:X}", self.control, self.prg_bank, self.chr_bank_1, self.chr_bank_2);
+            println!("control: 0x{:X}, prg: 0x{:X}, chr1: 0x{:X}, chr2: 0x{:X}", self.control, self.prg_bank, self.chr_bank_1, self.chr_bank_2);
         }
     }
 }

--- a/src/emulator/mappers.rs
+++ b/src/emulator/mappers.rs
@@ -1,5 +1,8 @@
 use emulator::memory;
 
+// iNES Mapper 0: NROM
+// Non-switchable PRG ROM, mirrorred to fill the space.
+// Non-switchable CHR ROM.
 pub struct NROM {
     prg_rom: Vec<u8>,
     chr_rom: Vec<u8>,
@@ -8,11 +11,6 @@ pub struct NROM {
 impl NROM {
     pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>) -> NROM {
         NROM { prg_rom, chr_rom }
-    }
-
-    #[inline]
-    fn map_prg_address(address: u16, prg_size: u16) -> u16 {
-        (address - 0x8000) % prg_size
     }
 }
 
@@ -26,11 +24,160 @@ impl memory::Mapper for NROM {
     }
 
     fn read_prg(&mut self, address: u16) -> u8 {
-        let mapped_address = NROM::map_prg_address(address, self.prg_rom.len() as u16);
-        self.prg_rom[mapped_address as usize]
+        self.prg_rom[((address - 0x8000) % self.prg_rom.len() as u16) as usize]
     }
 
     fn write_prg(&mut self, _address: u16, _byte: u8) {
         // Can't write to ROM.
+    }
+}
+
+// iNES Mapper 1: MMC1
+// 2 switchable 16k PRG ROM banks.
+// 2 switchable 4k CHR ROM banks.
+// Non-switchable CHR ROM.
+pub struct MMC1 {
+    prg_rom: Vec<u8>,
+    chr_rom: Vec<u8>,
+
+    load_register: u8,
+    write_index: u8,
+    control: u8,
+
+    prg_bank: u8,
+    chr_bank_1: u8,
+    chr_bank_2: u8,
+
+    prg_offsets: [u32; 2],
+    chr_offsets: [u32; 2],
+}
+
+impl MMC1 {
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>) -> MMC1 {
+        let mut mapper = MMC1 {
+            prg_rom,
+            chr_rom,
+
+            load_register: 0x10,
+            write_index: 0,
+
+            // 4bit0
+            // -----
+            // CPPMM
+            // |||||
+            // |||++- Mirroring (0: one-screen, lower bank; 1: one-screen, upper bank;
+            // |||               2: vertical; 3: horizontal)
+            // |++--- PRG ROM bank mode (0, 1: switch 32 KB at $8000, ignoring low bit of bank number;
+            // |                         2: fix first bank at $8000 and switch 16 KB bank at $C000;
+            // |                         3: fix last bank at $C000 and switch 16 KB bank at $8000)
+            // +----- CHR ROM bank mode (0: switch 8 KB at a time; 1: switch two separate 4 KB banks)
+            control: 0b0_1100,
+
+            prg_bank: 0,
+            chr_bank_1: 0,
+            chr_bank_2: 0,
+            prg_offsets: [0; 2],
+            chr_offsets: [0; 2],
+        };
+        mapper.update_offsets();
+        //mapper.prg_offsets[1] = mapper.prg_offset((mapper.prg_rom.len() as u32) / 0x4000 - 1);
+        mapper
+    }
+
+    fn update_offsets(&mut self) {
+        match (self.control & 0x0C) >> 2 {
+            0 | 1 => {
+                self.prg_offsets[0] = self.prg_offset((self.prg_bank as u32) & 0x0E);
+                self.prg_offsets[1] = self.prg_offset(((self.prg_bank as u32) | 0x01) & 0x0F);
+            },
+            2 => {
+                self.prg_offsets[0] = 0;
+                self.prg_offsets[1] = self.prg_offset((self.prg_bank as u32) & 0x0F);
+            },
+            3 => {
+                self.prg_offsets[0] = self.prg_offset((self.prg_bank as u32) & 0x0F);
+                self.prg_offsets[1] = self.prg_offset((self.prg_rom.len() as u32) / 0x4000 - 1);
+            },
+            _ => panic!("Invalid prg control value: {:b}", self.control),
+        }
+
+        match (self.control & 0x10) >> 4 {
+            0 => {
+                self.chr_offsets[0] = self.chr_offset((self.chr_bank_1 as u32) & 0x1E);
+                self.chr_offsets[1] = self.chr_offset((self.chr_bank_1 as u32) | 0x01);
+            },
+            1 => {
+                self.chr_offsets[0] = self.chr_offset((self.chr_bank_1 as u32) & 0x1E);
+                self.chr_offsets[1] = self.chr_offset((self.chr_bank_2 as u32) & 0x1E);
+            },
+            _ => panic!("Invalid chr control value: {:b}", self.control),
+        }
+    }
+
+    fn prg_offset(&self, index: u32) -> u32 {
+        (index % ((self.prg_rom.len() as u32) / 0x4000)) * 0x4000
+    }
+
+    fn chr_offset(&self, index: u32) -> u32 {
+        (index % ((self.chr_rom.len() as u32) / 0x1000)) * 0x1000
+    }
+}
+
+impl memory::Mapper for MMC1 {
+    fn read_chr(&mut self, address: u16) -> u8 {
+        let rel = address;
+        let bank = rel / 0x1000;
+        let offset = rel % 0x1000;
+        self.chr_rom[(self.chr_offsets[bank as usize] + (offset as u32)) as usize]
+    }
+
+    fn write_chr(&mut self, address: u16, byte: u8) {
+        let rel = address;
+        let bank = rel / 0x1000;
+        let offset = rel % 0x1000;
+        self.chr_rom[(self.chr_offsets[bank as usize] + (offset as u32)) as usize] = byte
+    }
+
+    fn read_prg(&mut self, address: u16) -> u8 {
+        let rel = address - 0x8000;
+        let bank = rel / 0x4000;
+        let offset = rel % 0x4000;
+        let final_addr = self.prg_offsets[bank as usize] + (offset as u32);
+        self.prg_rom[final_addr as usize]
+    }
+
+    fn write_prg(&mut self, address: u16, byte: u8) {
+        // If bit 7 is set, clear the register.
+        if byte & 0x80 != 0 {
+            self.load_register = 0;
+            self.write_index = 0;
+            return;
+        }
+
+        // Otherwise, shift bit into the register.
+        self.load_register >>= 1;
+        self.load_register |= (byte & 0x01) << 4;
+
+        // On the 5th write, copy into the correct register.
+        self.write_index += 1;
+        if self.write_index == 5 {
+            // Register is determined by bits 13 and 14 of the address written to.
+            {
+                let target_register = match address & 0xE000 {
+                    0x8000 => &mut self.control,
+                    0xA000 => &mut self.chr_bank_1,
+                    0xC000 => &mut self.chr_bank_2,
+                    0xE000 => &mut self.prg_bank,
+                    _ => panic!("Unexpected address: ${:X}", address),
+                };
+
+                *target_register = self.load_register;
+            }
+
+            self.load_register = 0;
+            self.write_index = 0;
+            self.update_offsets();
+            //println!("control: 0x{:X}, prg: 0x{:X}, chr1: 0x{:X}, chr2: 0x{:X}", self.control, self.prg_bank, self.chr_bank_1, self.chr_bank_2);
+        }
     }
 }

--- a/src/emulator/mappers.rs
+++ b/src/emulator/mappers.rs
@@ -1,15 +1,13 @@
 use emulator::memory;
-use emulator::memory::{Reader, Writer};
 
 pub struct NROM {
-    prg_size: u16,
-    prg_rom: memory::RAM,
-    chr_rom: memory::RAM,
+    prg_rom: Vec<u8>,
+    chr_rom: Vec<u8>,
 }
 
 impl NROM {
-    pub fn new(prg_size: u16, prg_rom: memory::RAM, chr_rom: memory::RAM) -> NROM {
-        NROM { prg_size, prg_rom, chr_rom }
+    pub fn new(prg_rom: Vec<u8>, chr_rom: Vec<u8>) -> NROM {
+        NROM { prg_rom, chr_rom }
     }
 
     #[inline]
@@ -20,20 +18,19 @@ impl NROM {
 
 impl memory::Mapper for NROM {
     fn read_chr(&mut self, address: u16) -> u8 {
-        self.chr_rom.read(address)
+        self.chr_rom[address as usize]
     }
 
-    fn write_chr(&mut self, address: u16, byte: u8) {
-        self.chr_rom.write(address, byte)
+    fn write_chr(&mut self, _address: u16, _byte: u8) {
+        // Can't write to ROM.
     }
 
     fn read_prg(&mut self, address: u16) -> u8 {
-        let mapped_address = NROM::map_prg_address(address, self.prg_size);
-        self.prg_rom.read(mapped_address)
+        let mapped_address = NROM::map_prg_address(address, self.prg_rom.len() as u16);
+        self.prg_rom[mapped_address as usize]
     }
 
-    fn write_prg(&mut self, address: u16, byte: u8) {
-        let mapped_address = NROM::map_prg_address(address, self.prg_size);
-        self.prg_rom.write(mapped_address, byte)
+    fn write_prg(&mut self, _address: u16, _byte: u8) {
+        // Can't write to ROM.
     }
 }

--- a/src/emulator/mappers.rs
+++ b/src/emulator/mappers.rs
@@ -12,8 +12,9 @@ impl NROM {
         NROM { prg_size, prg_rom, chr_rom }
     }
 
-    fn map_prg_address(&self, address: u16) -> u16 {
-        (address - 0x8000) % self.prg_size
+    #[inline]
+    fn map_prg_address(address: u16, prg_size: u16) -> u16 {
+        (address - 0x8000) % prg_size
     }
 }
 
@@ -27,12 +28,12 @@ impl memory::Mapper for NROM {
     }
 
     fn read_prg(&mut self, address: u16) -> u8 {
-        let mapped_address = self.map_prg_address(address);
+        let mapped_address = NROM::map_prg_address(address, self.prg_size);
         self.prg_rom.read(mapped_address)
     }
 
     fn write_prg(&mut self, address: u16, byte: u8) {
-        let mapped_address = self.map_prg_address(address);
+        let mapped_address = NROM::map_prg_address(address, self.prg_size);
         self.prg_rom.write(mapped_address, byte)
     }
 }

--- a/src/emulator/mappers.rs
+++ b/src/emulator/mappers.rs
@@ -1,0 +1,38 @@
+use emulator::memory;
+use emulator::memory::{Reader, Writer};
+
+pub struct NROM {
+    prg_size: u16,
+    prg_rom: memory::RAM,
+    chr_rom: memory::RAM,
+}
+
+impl NROM {
+    pub fn new(prg_size: u16, prg_rom: memory::RAM, chr_rom: memory::RAM) -> NROM {
+        NROM { prg_size, prg_rom, chr_rom }
+    }
+
+    fn map_prg_address(&self, address: u16) -> u16 {
+        (address - 0x8000) % self.prg_size
+    }
+}
+
+impl memory::Mapper for NROM {
+    fn read_chr(&mut self, address: u16) -> u8 {
+        self.chr_rom.read(address)
+    }
+
+    fn write_chr(&mut self, address: u16, byte: u8) {
+        self.chr_rom.write(address, byte)
+    }
+
+    fn read_prg(&mut self, address: u16) -> u8 {
+        let mapped_address = self.map_prg_address(address);
+        self.prg_rom.read(mapped_address)
+    }
+
+    fn write_prg(&mut self, address: u16, byte: u8) {
+        let mapped_address = self.map_prg_address(address);
+        self.prg_rom.write(mapped_address, byte)
+    }
+}

--- a/src/emulator/mappers.rs
+++ b/src/emulator/mappers.rs
@@ -1,4 +1,5 @@
 use emulator::memory;
+use emulator::ppu::MirrorMode;
 
 // iNES Mapper 0: NROM
 // Non-switchable PRG ROM, mirrorred to fill the space.
@@ -29,6 +30,10 @@ impl memory::Mapper for NROM {
 
     fn write_prg(&mut self, _address: u16, _byte: u8) {
         // Can't write to ROM.
+    }
+
+    fn mirror_mode(&self) -> MirrorMode {
+        MirrorMode::SINGLE_LOWER
     }
 }
 
@@ -174,9 +179,20 @@ impl memory::Mapper for MMC1 {
                 *target_register = self.load_register;
             }
 
+            //println!("${:X} = 0b{:b}", address, self.load_register);
             self.load_register = 0;
             self.write_index = 0;
             self.update_offsets();
+        }
+    }
+
+    fn mirror_mode(&self) -> MirrorMode {
+        match self.control & 0x3 {
+            0 => MirrorMode::SINGLE_LOWER,
+            1 => MirrorMode::SINGLE_UPPER,
+            2 => MirrorMode::VERTICAL,
+            3 => MirrorMode::HORIZONTAL,
+            _ => panic!("Unexpected mirror control: 0b{:b}", self.control),
         }
     }
 }

--- a/src/emulator/mappers.rs
+++ b/src/emulator/mappers.rs
@@ -107,8 +107,8 @@ impl MMC1 {
                 self.chr_offsets[1] = self.chr_offset((self.chr_bank_1 as u32) | 0x01);
             },
             1 => {
-                self.chr_offsets[0] = self.chr_offset((self.chr_bank_1 as u32) & 0x1E);
-                self.chr_offsets[1] = self.chr_offset((self.chr_bank_2 as u32) & 0x1E);
+                self.chr_offsets[0] = self.chr_offset((self.chr_bank_1 as u32) & 0x1F);
+                self.chr_offsets[1] = self.chr_offset((self.chr_bank_2 as u32) & 0x1F);
             },
             _ => panic!("Invalid chr control value: {:b}", self.control),
         }
@@ -177,7 +177,6 @@ impl memory::Mapper for MMC1 {
             self.load_register = 0;
             self.write_index = 0;
             self.update_offsets();
-            println!("control: 0x{:X}, prg: 0x{:X}, chr1: 0x{:X}, chr2: 0x{:X}", self.control, self.prg_bank, self.chr_bank_1, self.chr_bank_2);
         }
     }
 }

--- a/src/emulator/memory.rs
+++ b/src/emulator/memory.rs
@@ -14,15 +14,13 @@ pub trait Writer {
 pub trait ReadWriter : Reader + Writer {}
 impl<T: Reader + Writer> ReadWriter for T {}
 
-pub type MemoryRef = Rc<RefCell<dyn ReadWriter>>;
-
-impl Reader for MemoryRef {
+impl <M : Reader> Reader for Rc<RefCell<M>> {
     fn read(&mut self, address: u16) -> u8 {
         self.borrow_mut().read(address)
     }
 }
 
-impl Writer for MemoryRef {
+impl <M : Writer> Writer for Rc<RefCell<M>> {
     fn write(&mut self, address: u16, byte: u8) {
         self.borrow_mut().write(address, byte);
     }

--- a/src/emulator/memory.rs
+++ b/src/emulator/memory.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::collections::VecDeque;
 use std::rc::Rc;
 
 const ADDRESS_SPACE: usize = 65536;
@@ -15,72 +14,124 @@ pub trait Writer {
 pub trait ReadWriter : Reader + Writer {}
 impl<T: Reader + Writer> ReadWriter for T {}
 
-pub struct Manager {
-    modules: VecDeque<Module>,
-}
+pub type MemoryRef = Rc<RefCell<dyn ReadWriter>>;
 
-pub fn new() -> Manager {
-    let ram = Rc::new(RefCell::new(RAM::new()));
-    let module = Module{
-        delegate: ram,
-        start_addr: 0,
-        end_addr: (ADDRESS_SPACE-1) as u16,
-    };
-
-    let mut modules = VecDeque::new();
-    modules.push_back(module);
-
-    Manager{ modules }
-}
-
-impl Reader for Manager {
+impl Reader for MemoryRef {
     fn read(&mut self, address: u16) -> u8 {
-        let module = self.find_module(address).unwrap();
-        return module.delegate.borrow_mut().read(address);
+        self.borrow_mut().read(address)
     }
 }
 
-impl Writer for Manager {
+impl Writer for MemoryRef {
     fn write(&mut self, address: u16, byte: u8) {
-        let module = self.find_module(address).unwrap();
-        return module.delegate.borrow_mut().write(address, byte);
+        self.borrow_mut().write(address, byte);
     }
 }
 
-impl Manager {
-    pub fn mount(&mut self, delegate: Rc<RefCell<ReadWriter>>, start_addr: u16, end_addr: u16) {
-        if end_addr as usize >= ADDRESS_SPACE {
-            panic!("Mount end_addr is out of bounds: {} >= {}", end_addr as usize, ADDRESS_SPACE);
-        }
+pub struct CPUMemory {
+    ram: MemoryRef,
+    ppu_registers: MemoryRef,
+    apu_registers: MemoryRef,
+    prg_rom: MemoryRef,
+}
 
-        let module = Module{ delegate, start_addr, end_addr };
-
-        self.modules.push_front(module)
+impl CPUMemory {
+    pub fn new(ram: MemoryRef, ppu_registers: MemoryRef, apu_registers: MemoryRef, prg_rom: MemoryRef) -> CPUMemory {
+        CPUMemory { ram, ppu_registers, apu_registers, prg_rom }
     }
 
-    fn find_module(&mut self, addr: u16) -> Option<&mut Module> {
-        for module in self.modules.iter_mut() {
-            if module.start_addr <= addr && module.end_addr >= addr {
-                return Some(module);
-            }
+    fn map(&mut self, address: u16) -> Option<(&mut MemoryRef, u16)> {
+        match address {
+            0x0000 ... 0x1FFF => Some((&mut self.ram, address & 0x7FF)),
+            0x2000 ... 0x3FFF => Some((&mut self.ppu_registers, address & 0x7)),
+            0x4000 ... 0x401F => Some((&mut self.apu_registers, address)),
+            0x8000 ... 0xFFFF => Some((&mut self.prg_rom, address)),
+            _ => None
         }
-        return None;
-    }
-
-    pub fn debug_print(&mut self, start_addr: u16, num_bytes: u16) {
-        let end_addr = start_addr - 1 + num_bytes;
-        print!("MEMORY [{:X}..{:X}]:", start_addr, end_addr);
-        for ix in 0..num_bytes {
-            print!(" {:X}", self.read(start_addr + ix));
-        }
-        println!();
     }
 }
 
-struct Module {
-    delegate: Rc<RefCell<ReadWriter>>,
-    start_addr: u16,
-    end_addr: u16,
+impl Reader for CPUMemory {
+    fn read(&mut self, address: u16) -> u8 {
+        self.map(address).map(|(mem, addr)| mem.read(addr)).unwrap_or(0)
+    }
+}
+
+impl Writer for CPUMemory {
+    fn write(&mut self, address: u16, byte: u8) {
+        self.map(address).map(|(mem, addr)| mem.write(addr, byte));
+    }
+}
+
+pub trait Mapper {
+    fn read_chr(&mut self, address: u16) -> u8;
+    fn write_chr(&mut self, address: u16, byte: u8);
+    fn read_prg(&mut self, address: u16) -> u8;
+    fn write_prg(&mut self, address: u16, byte: u8);
+}
+
+pub type MapperRef = Rc<RefCell<dyn Mapper>>;
+
+impl Mapper for MapperRef {
+    fn read_chr(&mut self, address: u16) -> u8 {
+        self.borrow_mut().read_chr(address)
+    }
+
+    fn write_chr(&mut self, address: u16, byte: u8) {
+        self.borrow_mut().write_chr(address, byte)
+    }
+
+    fn read_prg(&mut self, address: u16) -> u8 {
+        self.borrow_mut().read_prg(address)
+    }
+
+    fn write_prg(&mut self, address: u16, byte: u8) {
+        self.borrow_mut().write_prg(address, byte)
+    }
+}
+
+pub struct PrgMapper<M : Mapper> {
+    mapper: M,
+}
+
+impl <M : Mapper> PrgMapper<M> {
+    pub fn new(mapper: M) -> PrgMapper<M> {
+        PrgMapper { mapper }
+    }
+}
+
+impl <M : Mapper> Reader for PrgMapper<M> {
+    fn read(&mut self, address: u16) -> u8 {
+        self.mapper.read_prg(address)
+    }
+}
+
+impl <M : Mapper> Writer for PrgMapper<M> {
+    fn write(&mut self, address: u16, byte: u8) {
+        self.mapper.write_prg(address, byte)
+    }
+}
+
+pub struct ChrMapper<M : Mapper> {
+    mapper: M,
+}
+
+impl <M : Mapper> ChrMapper<M> {
+    pub fn new(mapper: M) -> ChrMapper<M> {
+        ChrMapper { mapper }
+    }
+}
+
+impl <M : Mapper> Reader for ChrMapper<M> {
+    fn read(&mut self, address: u16) -> u8 {
+        self.mapper.read_chr(address)
+    }
+}
+
+impl <M : Mapper> Writer for ChrMapper<M> {
+    fn write(&mut self, address: u16, byte: u8) {
+        self.mapper.write_chr(address, byte)
+    }
 }
 
 pub struct RAM {
@@ -114,7 +165,7 @@ impl RAM {
 
 #[test]
 fn test_get_and_set() {
-    let mut ram = new();
+    let mut ram = RAM::new();
     ram.write(1234, 23);
     assert_eq!(ram.read(1234), 23);
 }

--- a/src/emulator/memory.rs
+++ b/src/emulator/memory.rs
@@ -30,12 +30,13 @@ pub struct CPUMemory {
     ram: Box<dyn ReadWriter>,
     ppu_registers: Box<dyn ReadWriter>,
     apu_registers: Box<dyn ReadWriter>,
+    sram: Box<dyn ReadWriter>,
     prg_rom: Box<dyn ReadWriter>,
 }
 
 impl CPUMemory {
-    pub fn new(ram: Box<dyn ReadWriter>, ppu_registers: Box<dyn ReadWriter>, apu_registers: Box<dyn ReadWriter>, prg_rom: Box<dyn ReadWriter>) -> CPUMemory {
-        CPUMemory { ram, ppu_registers, apu_registers, prg_rom }
+    pub fn new(ram: Box<dyn ReadWriter>, ppu_registers: Box<dyn ReadWriter>, apu_registers: Box<dyn ReadWriter>, sram: Box<dyn ReadWriter>, prg_rom: Box<dyn ReadWriter>) -> CPUMemory {
+        CPUMemory { ram, ppu_registers, apu_registers, sram, prg_rom }
     }
 
     fn map(&mut self, address: u16) -> Option<(&mut Box<dyn ReadWriter>, u16)> {
@@ -43,6 +44,7 @@ impl CPUMemory {
             0x0000 ... 0x1FFF => Some((&mut self.ram, address & 0x7FF)),
             0x2000 ... 0x3FFF => Some((&mut self.ppu_registers, address & 0x7)),
             0x4000 ... 0x401F => Some((&mut self.apu_registers, address)),
+            0x6000 ... 0x7FFF => Some((&mut self.sram, address - 0x6000)),
             0x8000 ... 0xFFFF => Some((&mut self.prg_rom, address)),
             _ => None
         }
@@ -74,7 +76,7 @@ impl PPUMemory {
     fn map(&mut self, address: u16) -> Option<(&mut Box<dyn ReadWriter>, u16)> {
         match address {
             0x0000 ... 0x1FFF => Some((&mut self.chr_rom, address)),
-            0x2000 ... 0x3FFF => Some((&mut self.vram, address)),
+            0x2000 ... 0x3FFF => Some((&mut self.vram, address & !0x0800)),
             _ => None
         }
     }

--- a/src/emulator/memory.rs
+++ b/src/emulator/memory.rs
@@ -29,18 +29,18 @@ impl Writer for MemoryRef {
 }
 
 pub struct CPUMemory {
-    ram: MemoryRef,
-    ppu_registers: MemoryRef,
-    apu_registers: MemoryRef,
-    prg_rom: MemoryRef,
+    ram: Box<dyn ReadWriter>,
+    ppu_registers: Box<dyn ReadWriter>,
+    apu_registers: Box<dyn ReadWriter>,
+    prg_rom: Box<dyn ReadWriter>,
 }
 
 impl CPUMemory {
-    pub fn new(ram: MemoryRef, ppu_registers: MemoryRef, apu_registers: MemoryRef, prg_rom: MemoryRef) -> CPUMemory {
+    pub fn new(ram: Box<dyn ReadWriter>, ppu_registers: Box<dyn ReadWriter>, apu_registers: Box<dyn ReadWriter>, prg_rom: Box<dyn ReadWriter>) -> CPUMemory {
         CPUMemory { ram, ppu_registers, apu_registers, prg_rom }
     }
 
-    fn map(&mut self, address: u16) -> Option<(&mut MemoryRef, u16)> {
+    fn map(&mut self, address: u16) -> Option<(&mut Box<dyn ReadWriter>, u16)> {
         match address {
             0x0000 ... 0x1FFF => Some((&mut self.ram, address & 0x7FF)),
             0x2000 ... 0x3FFF => Some((&mut self.ppu_registers, address & 0x7)),

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -62,8 +62,8 @@ impl NES {
         cpu.borrow_mut().startup_sequence();
 
         // Wire up the clock timings.
-        let cpu_ticker = clock::ScaledTicker::new(Box::new(cpu.clone() as clock::TickerRef), NES_CPU_CLOCK_FACTOR);
-        let ppu_ticker = clock::ScaledTicker::new(Box::new(ppu.clone() as clock::TickerRef), NES_PPU_CLOCK_FACTOR);
+        let cpu_ticker = clock::ScaledTicker::new(Box::new(cpu.clone()), NES_CPU_CLOCK_FACTOR);
+        let ppu_ticker = clock::ScaledTicker::new(Box::new(ppu.clone()), NES_PPU_CLOCK_FACTOR);
         clock.manage(Box::new(cpu_ticker));
         clock.manage(Box::new(ppu_ticker));
 

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -46,6 +46,7 @@ impl NES {
 
         let ppu_memory = Box::new(memory::PPUMemory::new(
             Box::new(memory::ChrMapper::new(mapper.clone())),
+            Box::new(mapper.clone()),
             Box::new(memory::RAM::new()),
         ));
 

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -13,7 +13,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use emulator::io::sdl;
-use emulator::memory::{MemoryRef, Writer};
+use emulator::memory::Writer;
 
 // Timings (NTSC).
 // Master clock = 21.477272 MHz ~= 46.5ns per clock.
@@ -49,10 +49,9 @@ impl NES {
                     Box::new(output))));
         
         // Create CPU.
-        let ppu_registers: MemoryRef = ppu.clone();
         let cpu_memory = Box::new(memory::CPUMemory::new(
             Box::new(memory::RAM::new()),
-            Box::new(ppu_registers),
+            Box::new(ppu.clone()),
             Box::new(memory::RAM::new()),
             Box::new(memory::PrgMapper::new(mapper.clone()))
         ));

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -45,8 +45,7 @@ impl NES {
         let output = sdl::Graphics::new(io);
 
         let ppu_memory = Box::new(memory::PPUMemory::new(
-            //Box::new(memory::ChrMapper::new(mapper.clone())),
-            Box::new(memory::RAM::new()),
+            Box::new(memory::ChrMapper::new(mapper.clone())),
             Box::new(memory::RAM::new()),
         ));
 

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -45,7 +45,8 @@ impl NES {
         let output = sdl::Graphics::new(io);
 
         let ppu_memory = Box::new(memory::PPUMemory::new(
-            Box::new(memory::ChrMapper::new(mapper.clone())),
+            //Box::new(memory::ChrMapper::new(mapper.clone())),
+            Box::new(memory::RAM::new()),
             Box::new(memory::RAM::new()),
         ));
 
@@ -57,6 +58,7 @@ impl NES {
         let cpu_memory = Box::new(memory::CPUMemory::new(
             Box::new(memory::RAM::new()),
             Box::new(ppu.clone()),
+            Box::new(memory::RAM::new()),
             Box::new(memory::RAM::new()),
             Box::new(memory::PrgMapper::new(mapper.clone()))
         ));
@@ -97,9 +99,13 @@ impl NES {
     }
 
     pub fn load(rom: ines::ROM) -> memory::MapperRef {
-        let prg_rom = Vec::from(rom.prg_rom());
-        let chr_rom = Vec::from(rom.chr_rom());
+        let prg_rom = rom.prg_rom().to_vec();
+        let chr_rom = rom.chr_rom().to_vec();
 
-        Rc::new(RefCell::new(mappers::NROM::new(prg_rom, chr_rom)))
+        match rom.mapper_number() {
+            0 => Rc::new(RefCell::new(mappers::NROM::new(prg_rom, chr_rom))),
+            1 => Rc::new(RefCell::new(mappers::MMC1::new(prg_rom, chr_rom))),
+            _ => panic!("Unknown mapper: {}", rom.mapper_number()),
+        }
     }
 }

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -76,7 +76,7 @@ pub struct PPU {
     // $3000-$3EFF = mirrors of $2000-$2EFF
     // $3F00-$3F1F = palette RAM indexes
     // $3F20-$3FFF = mirrors of $3F00-$3F1F
-    memory: Box<ReadWriter>,
+    memory: Box<dyn ReadWriter>,
 
     // -- Background State --
 

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -76,7 +76,7 @@ pub struct PPU {
     // $3000-$3EFF = mirrors of $2000-$2EFF
     // $3F00-$3F1F = palette RAM indexes
     // $3F20-$3FFF = mirrors of $3F00-$3F1F
-    memory: memory::RAM,
+    memory: memory::MemoryRef,
 
     // -- Background State --
 
@@ -152,7 +152,7 @@ impl clock::Ticker for PPU {
 }
 
 impl PPU {
-    pub fn new(memory: memory::RAM, output: Box<VideoOut>) -> PPU {
+    pub fn new(memory: memory::MemoryRef, output: Box<VideoOut>) -> PPU {
         PPU {
             output: output,
             ppuctrl: BitField::new(),

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -44,6 +44,17 @@ pub trait VideoOut {
     fn emit(&mut self, c: Colour);
 }
 
+pub enum MirrorMode {
+    SINGLE_LOWER,
+    SINGLE_UPPER,
+    VERTICAL,
+    HORIZONTAL,
+}
+
+pub trait Mirrorer {
+    fn mirror_mode(&self) -> MirrorMode;
+}
+
 pub struct PPU {
     // Device to output rendered pixels to.
     output: Box<VideoOut>,

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -146,6 +146,7 @@ pub struct PPU {
 }
 
 impl clock::Ticker for PPU {
+    #[inline]
     fn tick(&mut self) -> u32 {
         self.tick_internal() as u32
     }

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -8,7 +8,7 @@ use emulator::clock;
 use emulator::components::bitfield::BitField;
 use emulator::components::latch;
 use emulator::memory;
-use emulator::memory::{Reader, ReadWriter};
+use emulator::memory::ReadWriter;
 
 // Colours represented as a single byte:
 // 76543210

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -8,7 +8,7 @@ use emulator::clock;
 use emulator::components::bitfield::BitField;
 use emulator::components::latch;
 use emulator::memory;
-use emulator::memory::Reader;
+use emulator::memory::{Reader, ReadWriter};
 
 // Colours represented as a single byte:
 // 76543210
@@ -76,7 +76,7 @@ pub struct PPU {
     // $3000-$3EFF = mirrors of $2000-$2EFF
     // $3F00-$3F1F = palette RAM indexes
     // $3F20-$3FFF = mirrors of $3F00-$3F1F
-    memory: memory::MemoryRef,
+    memory: Box<ReadWriter>,
 
     // -- Background State --
 
@@ -152,7 +152,7 @@ impl clock::Ticker for PPU {
 }
 
 impl PPU {
-    pub fn new(memory: memory::MemoryRef, output: Box<VideoOut>) -> PPU {
+    pub fn new(memory: Box<ReadWriter>, output: Box<VideoOut>) -> PPU {
         PPU {
             output: output,
             ppuctrl: BitField::new(),

--- a/src/emulator/ppu/registers.rs
+++ b/src/emulator/ppu/registers.rs
@@ -77,9 +77,15 @@ impl Reader for PPU {
 
 impl Writer for PPU {
     fn write(&mut self, address: u16, byte: u8) {
+        //println!("${:X} = 0x{:X}", address, byte);
         match address % 8 {
             // PPUCTRL
-            0 => self.ppuctrl.load_byte(byte),
+            0 => {
+                // Load ppuctrl and also set base nametable bits in t.
+                self.ppuctrl.load_byte(byte);
+                self.t &= 0xF3FF;
+                self.t |= ((byte & 0b11) as u16) << 10;
+            },
 
             // PPUMASK
             1 => self.ppumask.load_byte(byte),

--- a/src/emulator/ppu/registers.rs
+++ b/src/emulator/ppu/registers.rs
@@ -77,7 +77,6 @@ impl Reader for PPU {
 
 impl Writer for PPU {
     fn write(&mut self, address: u16, byte: u8) {
-        //println!("${:X} = 0x{:X}", address, byte);
         match address % 8 {
             // PPUCTRL
             0 => {

--- a/src/emulator/ppu/test/mod.rs
+++ b/src/emulator/ppu/test/mod.rs
@@ -11,7 +11,7 @@ use emulator::ppu::PPU;
 use emulator::ppu::VideoOut;
 
 fn new_ppu(output: Box<VideoOut>) -> PPU {
-    PPU::new(Rc::new(RefCell::new(memory::RAM::new())), output)
+    PPU::new(Box::new(memory::RAM::new()), output)
 }
 
 fn load_data_into_vram(ppu: &mut PPU, addr: u16, bytes: &[u8]) {

--- a/src/emulator/ppu/test/mod.rs
+++ b/src/emulator/ppu/test/mod.rs
@@ -1,6 +1,9 @@
 mod background;
 mod data;
 
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use emulator::memory;
 use emulator::memory::Writer;
 use emulator::ppu::Colour;
@@ -8,7 +11,7 @@ use emulator::ppu::PPU;
 use emulator::ppu::VideoOut;
 
 fn new_ppu(output: Box<VideoOut>) -> PPU {
-    PPU::new(memory::RAM::new(), output)
+    PPU::new(Rc::new(RefCell::new(memory::RAM::new())), output)
 }
 
 fn load_data_into_vram(ppu: &mut PPU, addr: u16, bytes: &[u8]) {

--- a/src/emulator/ppu/test/mod.rs
+++ b/src/emulator/ppu/test/mod.rs
@@ -1,11 +1,7 @@
 mod background;
 mod data;
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use emulator::memory;
-use emulator::memory::Writer;
 use emulator::ppu::Colour;
 use emulator::ppu::PPU;
 use emulator::ppu::VideoOut;


### PR DESCRIPTION
Add framework for mappers and implement MMC1.

Now we can boot many more games!
I think there are still some bugs, but it seems to work well in many cases.  Merging for now.

Examples:

**Zelda**
![zelda](https://user-images.githubusercontent.com/3620166/47907307-5544c680-dece-11e8-920c-6906e791a9dd.gif)


**Metroid**
![metroid](https://user-images.githubusercontent.com/3620166/47907218-229ace00-dece-11e8-9587-59364f4bd56f.gif)


