### PR TITLE
Refactor IO and fix some small bugs

### DIFF
--- a/src/bin/nes.rs
+++ b/src/bin/nes.rs
@@ -1,7 +1,6 @@
 extern crate mos_6500;
 
 use std::cell::RefCell;
-use std::cmp::{max, min};
 use std::env;
 use std::rc::Rc;
 use std::thread;

--- a/src/bin/nes.rs
+++ b/src/bin/nes.rs
@@ -1,9 +1,19 @@
 extern crate mos_6500;
 
+use std::cell::RefCell;
+use std::cmp::{max, min};
 use std::env;
+use std::rc::Rc;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use mos_6500::emulator;
+use mos_6500::emulator::clock::Ticker;
 use mos_6500::emulator::ines;
+use mos_6500::emulator::io;
+use mos_6500::emulator::io::{Input};
+use mos_6500::emulator::io::event::{Event, EventHandler, Key};
+use mos_6500::emulator::io::sdl;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -15,7 +25,126 @@ fn main() {
 
     let rom = ines::ROM::load(rom_path);
 
-    let mut nes = emulator::NES::new(rom);
+    let io = Rc::new(RefCell::new(sdl::IO::new()));
+    let output = io::SimpleVideoOut::new(io.clone());
 
-    nes.run_blocking();
+    let mut nes = emulator::NES::new(io.clone(), output, rom);
+
+    let lifecycle = Rc::new(RefCell::new(Lifecycle::new()));
+    lifecycle.borrow_mut().start();
+    io.borrow_mut().register_event_handler(Box::new(lifecycle.clone()));
+
+    let started_instant = Instant::now();
+    let frames_per_second = 30;
+    let mut frame_start = started_instant;
+    let mut frame_ix = 0;
+    let mut agg_cycles = 0;
+    let mut agg_start = started_instant;
+    let mut overflow_cycles = 0;
+
+    while lifecycle.borrow().is_running() {
+        let target_hz = lifecycle.borrow().target_hz();
+        let target_frame_cycles = target_hz / frames_per_second;
+        let target_frame_time_ns = 1_000_000_000 / frames_per_second;
+
+        let mut cycles_this_frame = 0;
+        let target_cycles_this_frame = target_frame_cycles - overflow_cycles;
+        let mut frame_ns = 0;
+
+        while cycles_this_frame < target_cycles_this_frame && frame_ns < target_frame_time_ns {
+            // Batching ticks here is a massive perf win since finding the elapsed time is costly.
+            // Reduce batch size when we're nearly done with a frame to try and get really close to
+            // the exact number.
+            let batch_size = 100;//max(1, min(1_000, (target_frame_cycles - cycles_this_frame) / 1000));
+            for _ in 1 .. batch_size {
+                cycles_this_frame += nes.tick();
+            }
+
+            let frame_time = frame_start.elapsed();
+            frame_ns = frame_time.as_secs() * 1_000_000_000 + (frame_time.subsec_nanos() as u64);
+        }
+
+        io.borrow_mut().tick();
+
+        let frame_end = Instant::now();
+        let frame_time = frame_end - frame_start;
+        frame_ns = frame_time.as_secs() * 1_000_000_000 + (frame_time.subsec_nanos() as u64);
+        let sleep_ns = target_frame_time_ns.saturating_sub(frame_ns);
+
+        // Set frame_start to what we INTEND for it to be, so we will adjust for the sleep not
+        // being an exact amount.
+        frame_start = frame_end + Duration::from_nanos(sleep_ns);
+        overflow_cycles = cycles_this_frame.saturating_sub(target_cycles_this_frame);
+        thread::sleep(Duration::from_nanos(sleep_ns));
+        
+        // Print debug info here.
+        agg_cycles += cycles_this_frame;
+        frame_ix = (frame_ix + 1) % frames_per_second;
+        if frame_ix == 0 {
+            let agg_duration = agg_start.elapsed();
+            agg_start = Instant::now();
+
+            let agg_ns = agg_duration.as_secs() * 1_000_000_000 + (agg_duration.subsec_nanos() as u64);
+            let current_hz = (agg_cycles * 1_000_000_000) / agg_ns;
+
+            println!(
+                "Target: {:.3}MHz, Current: {:.3}MHz ({:.2}x)",
+                (target_hz as f64) / 1_000_000f64,
+                (current_hz as f64) / 1_000_000f64,
+                (current_hz as f64) / (emulator::NES_MASTER_CLOCK_HZ as f64),
+            );
+
+            agg_cycles = 0;
+        }
+    }
+}
+
+pub struct Lifecycle {
+    is_running: bool,
+    unlock_speed: bool,
+    target_hz: u64,
+}
+
+impl Lifecycle {
+    pub fn new() -> Lifecycle {
+        Lifecycle {
+            is_running: false,
+            unlock_speed: false,
+            target_hz: emulator::NES_MASTER_CLOCK_HZ,
+        }
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.is_running
+    }
+
+    pub fn start(&mut self) {
+        self.is_running = true;
+    }
+
+    pub fn speed_is_unlocked(&self) -> bool {
+        self.unlock_speed
+    }
+
+    pub fn target_hz(&self) -> u64 {
+        self.target_hz
+    }
+}
+
+impl EventHandler for Lifecycle {
+    fn handle_event(&mut self, event: Event) {
+        match event {
+            Event::KeyDown(key) => {
+                match key {
+                    Key::Escape => self.is_running = false,
+                    Key::Tab => self.unlock_speed = !self.unlock_speed,
+                    Key::Minus => self.target_hz /= 2,
+                    Key::Equals => self.target_hz *= 2,
+                    Key::Num0 => self.target_hz = emulator::NES_MASTER_CLOCK_HZ,
+                    _ => (),
+                };
+            },
+            _ => (),
+        };
+    }
 }

--- a/src/bin/nes.rs
+++ b/src/bin/nes.rs
@@ -1,9 +1,6 @@
 extern crate mos_6500;
 
 use std::env;
-use std::fs::File;
-use std::io::Write;
-use std::path::Path;
 
 use mos_6500::emulator;
 use mos_6500::emulator::ines;
@@ -14,17 +11,6 @@ fn main() {
     let rom_path = match args.get(2) {
         None => panic!("You must pass in a path to a iNes ROM file."),
         Some(path) => path,
-    };
-
-    let trace_enabled = match env::var("NES_TRACE") {
-        Err(_) => false,
-        Ok(val) => val == "1",
-    };
-
-    let trace_out_path = Path::new("./cpu.trace");
-    let trace_out = match File::create(trace_out_path) {
-        Err(cause) => panic!("Couldn't open {}: {}", trace_out_path.display(), cause),
-        Ok(file) => file,
     };
 
     let rom = ines::ROM::load(rom_path);

--- a/src/emulator/clock.rs
+++ b/src/emulator/clock.rs
@@ -6,8 +6,6 @@ use std::time::{Duration, Instant};
 use std::thread;
 use std::vec::Vec;
 
-const DRIFT_RECONCILIATION_FREQUENCY: u64 = 1_000;
-
 pub trait Ticker {
     // Returns how many master clock cycles while ticking.
     fn tick(&mut self) -> u32;
@@ -43,12 +41,14 @@ pub struct Clock {
     cycle_duration_ps: u64,
     pause_threshold_ns: u64,
     started_instant: Instant,
+    last_sync_ns: u64,
 
     // Timing.
     num_ticks: u64,
     elapsed_cycles: u64,
     elapsed_seconds: u64,
     cycles_this_second: u64,
+    cycles_since_sync: u64,
 
     // Tickers.
     tickers: Vec<Box<dyn Ticker>>,
@@ -63,8 +63,10 @@ impl Clock {
             elapsed_cycles: 0,
             elapsed_seconds: 0,
             cycles_this_second: 0,
+            cycles_since_sync: 0,
             pause_threshold_ns: pause_threshold_ns,
             started_instant: Instant::now(),
+            last_sync_ns: 0,
             tickers: Vec::new(),
             turn_order: BinaryHeap::new(),
         }
@@ -74,26 +76,12 @@ impl Clock {
         match self.turn_order.peek_mut() {
             Some(mut node) => {
                 self.cycles_this_second += node.next_tick_cycle - self.elapsed_cycles;
+                self.cycles_since_sync += node.next_tick_cycle - self.elapsed_cycles;
                 self.elapsed_cycles = node.next_tick_cycle;
                 let cycles = self.tickers[node.ticker_ix].tick();
                 node.next_tick_cycle = self.elapsed_cycles + (cycles as u64);
             },
             None => ()
-        }
-
-        if self.num_ticks % DRIFT_RECONCILIATION_FREQUENCY == 0 {
-            let running_time = self.started_instant.elapsed();
-            let running_time_ns = running_time.as_secs() * 1_000_000_000 + (running_time.subsec_nanos() as u64);
-            let drift_ns = ((self.elapsed_cycles * self.cycle_duration_ps) / 1000).saturating_sub(running_time_ns);
-            if drift_ns > self.pause_threshold_ns {
-                thread::sleep(Duration::from_nanos(drift_ns));
-            }
-
-            if self.elapsed_seconds != running_time.as_secs() {
-                self.elapsed_seconds = running_time.as_secs();
-                println!("Running for {} second(s).  Executed {} master clock cycles total.  Avg {}Hz.  Current: {}Hz.", self.elapsed_seconds, self.elapsed_cycles, self.elapsed_cycles / self.elapsed_seconds, self.cycles_this_second);
-                self.cycles_this_second = 0;
-            }
         }
 
         self.num_ticks += 1;
@@ -110,6 +98,45 @@ impl Clock {
             next_tick_cycle: self.elapsed_cycles,
         };
         self.turn_order.push(node);
+    }
+
+    pub fn synchronize(&mut self) {
+        let elapsed_time = self.started_instant.elapsed();
+        let time_ns = elapsed_time.as_secs() * 1_000_000_000 + (elapsed_time.subsec_nanos() as u64);
+        let since_sync_ns = time_ns - self.last_sync_ns;
+        let drift_ns = ((self.cycles_since_sync * self.cycle_duration_ps) / 1000).saturating_sub(since_sync_ns);
+        if drift_ns > self.pause_threshold_ns {
+            thread::sleep(Duration::from_nanos(drift_ns));
+        }
+
+        let elapsed_seconds = self.started_instant.elapsed().as_secs();
+        if self.elapsed_seconds != elapsed_seconds {
+            self.elapsed_seconds = elapsed_seconds;
+            let nes_freq = 21.477f64;
+            let target_freq = 1_000_000f64 / (self.cycle_duration_ps as f64);
+            let actual_freq = (self.cycles_this_second as f64) / 1_000_000f64;
+            println!("Target: {:.3}MHz,  Current: {:.3}MHz ({:.1}x).",
+                 target_freq,
+                 actual_freq,
+                 actual_freq / nes_freq,
+            );
+            self.cycles_this_second = 0;
+        }
+    }
+
+    pub fn set_master_clock(&mut self, duration_ps: u64) {
+        if duration_ps == self.cycle_duration_ps {
+            return;
+        }
+
+        self.cycle_duration_ps = duration_ps;
+
+        // Reset sync state, because changing the clock speed screws it all up.
+        let elapsed_time = self.started_instant.elapsed();
+        let time_ns = elapsed_time.as_secs() * 1_000_000_000 + (elapsed_time.subsec_nanos() as u64);
+        self.last_sync_ns = time_ns;
+        self.cycles_since_sync = 0;
+
     }
 }
 

--- a/src/emulator/clock.rs
+++ b/src/emulator/clock.rs
@@ -115,7 +115,7 @@ impl Clock {
             let nes_freq = 21.477f64;
             let target_freq = 1_000_000f64 / (self.cycle_duration_ps as f64);
             let actual_freq = (self.cycles_this_second as f64) / 1_000_000f64;
-            println!("Target: {:.3}MHz,  Current: {:.3}MHz ({:.1}x).",
+            println!("Target: {:.3}MHz,  Current: {:.3}MHz ({:.2}x).",
                  target_freq,
                  actual_freq,
                  actual_freq / nes_freq,

--- a/src/emulator/controller.rs
+++ b/src/emulator/controller.rs
@@ -1,11 +1,6 @@
-extern crate sdl2;
-
 use std::collections::HashMap;
 
-use self::sdl2::event;
-use self::sdl2::keyboard::Keycode;
-
-use emulator::io::EventHandler;
+use emulator::io::event::{Event, EventHandler, Key};
 use emulator::memory::{Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -15,7 +10,7 @@ pub enum Button {
     Up, Down, Left, Right,
 }
 
-pub type KeyMap = HashMap<Keycode, Button>;
+pub type KeyMap = HashMap<Key, Button>;
 
 pub type KeyState = HashMap<Button, bool>;
 
@@ -49,20 +44,16 @@ impl Controller {
 }
 
 impl EventHandler for Controller {
-    fn handle_event(&mut self, event: &event::Event) {
+    fn handle_event(&mut self, event: Event) {
         match event {
-            event::Event::KeyDown { keycode, .. } => {
-                if let Some(key) = keycode {
-                    if let Some(button) = self.keymap.get(key) {
-                        self.keystate.insert(*button, true);
-                    }
+            Event::KeyDown(key) => {
+                if let Some(button) = self.keymap.get(&key) {
+                    self.keystate.insert(*button, true);
                 }
             },
-            event::Event::KeyUp { keycode, .. } => {
-                if let Some(key) = keycode {
-                    if let Some(button) = self.keymap.get(key) {
-                        self.keystate.insert(*button, false);
-                    }
+            Event::KeyUp(key) => {
+                if let Some(button) = self.keymap.get(&key) {
+                    self.keystate.insert(*button, false);
                 }
             },
             _ => (),

--- a/src/emulator/controller.rs
+++ b/src/emulator/controller.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use self::sdl2::event;
 use self::sdl2::keyboard::Keycode;
 
-use emulator::io::sdl;
+use emulator::io::EventHandler;
 use emulator::memory::{Reader, Writer};
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -48,7 +48,7 @@ impl Controller {
     }
 }
 
-impl sdl::EventHandler for Controller {
+impl EventHandler for Controller {
     fn handle_event(&mut self, event: &event::Event) {
         match event {
             event::Event::KeyDown { keycode, .. } => {

--- a/src/emulator/controller.rs
+++ b/src/emulator/controller.rs
@@ -56,7 +56,6 @@ impl EventHandler for Controller {
                     self.keystate.insert(*button, false);
                 }
             },
-            _ => (),
         }
     }
 }

--- a/src/emulator/ines.rs
+++ b/src/emulator/ines.rs
@@ -61,9 +61,9 @@ impl ROM {
 
     pub fn mirror_mode(&self) -> ppu::MirrorMode {
         if self.data[6] & 0x1 == 0 {
-            ppu::MirrorMode::HORIZONTAL
+            ppu::MirrorMode::Horizontal
         } else {
-            ppu::MirrorMode::VERTICAL
+            ppu::MirrorMode::Vertical
         }
     }
 }

--- a/src/emulator/io/event.rs
+++ b/src/emulator/io/event.rs
@@ -1,0 +1,29 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+// Framework agnostic internal event types.
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Event {
+    KeyDown(Key),
+    KeyUp(Key),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Key {
+    A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z,
+    Num1, Num2, Num3, Num4, Num5, Num6, Num7, Num8, Num9, Num0,
+    Up, Down, Left, Right,
+    Minus, Equals,
+    Escape, Return, Tab, Space,
+}
+
+pub trait EventHandler {
+    fn handle_event(&mut self, event: Event);
+}
+
+impl <H : EventHandler> EventHandler for Rc<RefCell<H>> {
+    fn handle_event(&mut self, event: Event) {
+        self.borrow_mut().handle_event(event);
+    }
+}

--- a/src/emulator/io/mod.rs
+++ b/src/emulator/io/mod.rs
@@ -1,3 +1,88 @@
+extern crate sdl2;
+
 pub mod nop;
 pub mod palette;
 pub mod sdl;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use emulator::io::palette::PALETTE;
+use emulator::ppu;
+
+use self::sdl2::event;
+
+pub trait Input {
+    fn register_event_handler(&mut self, handler: Box<dyn EventHandler>);
+}
+
+pub trait Graphics {
+    fn draw_screen(&mut self, pixel_data: &[u8]);
+}
+
+pub trait EventHandler {
+    fn handle_event(&mut self, event: &event::Event);
+}
+
+impl <H : EventHandler> EventHandler for Rc<RefCell<H>> {
+    fn handle_event(&mut self, event: &event::Event) {
+        self.borrow_mut().handle_event(event);
+    }
+}
+
+pub struct SimpleVideoOut {
+    io: Rc<RefCell<dyn Graphics>>,
+    scanline: u32,
+    dot: u32,
+    screen_buffer: [u8; 256 * 240 * 3],
+    render_tile_grid: bool,
+}
+
+impl ppu::VideoOut for SimpleVideoOut {
+    fn emit(&mut self, c: ppu::Colour) {
+        let x = self.dot;
+        let y = self.scanline;
+
+        let (r, g, b) = if self.render_tile_grid && (x % 8 == 0 || y % 8 == 0) {
+            (255, 0, 0)
+        } else {
+            SimpleVideoOut::convert_colour(c)
+        };
+
+        self.screen_buffer[((x + y * 256) * 3) as usize] = r;
+        self.screen_buffer[((x + y * 256) * 3 + 1) as usize] = g;
+        self.screen_buffer[((x + y * 256) * 3 + 2) as usize] = b;
+
+        self.dot = (self.dot + 1) % 256;
+        if self.dot == 0 {
+            self.scanline = (self.scanline + 1) % 240;
+            if self.scanline == 0 {
+                self.render();
+            }
+        }
+    }
+}
+
+impl SimpleVideoOut {
+    pub fn new(io: Rc<RefCell<Graphics>>) -> SimpleVideoOut {
+        SimpleVideoOut {
+            io,
+            scanline: 0,
+            dot: 0,
+            screen_buffer: [0; 256 * 240 * 3],
+            render_tile_grid: false,
+        }
+    }
+
+    fn render(&mut self) {
+        self.io.borrow_mut().draw_screen(&self.screen_buffer);
+    }
+
+    fn convert_colour(c: ppu::Colour) -> (u8, u8, u8) {
+        let (r, g, b) = match PALETTE.get(c.as_byte() as usize) {
+            None => (0, 0, 0),
+            Some(colour) => *colour,
+        };
+        (r, g, b)
+    }
+}

--- a/src/emulator/io/mod.rs
+++ b/src/emulator/io/mod.rs
@@ -1,5 +1,4 @@
-extern crate sdl2;
-
+pub mod event;
 pub mod nop;
 pub mod palette;
 pub mod sdl;
@@ -7,10 +6,9 @@ pub mod sdl;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use emulator::io::event::EventHandler;
 use emulator::io::palette::PALETTE;
 use emulator::ppu;
-
-use self::sdl2::event;
 
 pub trait Input {
     fn register_event_handler(&mut self, handler: Box<dyn EventHandler>);
@@ -18,16 +16,6 @@ pub trait Input {
 
 pub trait Graphics {
     fn draw_screen(&mut self, pixel_data: &[u8]);
-}
-
-pub trait EventHandler {
-    fn handle_event(&mut self, event: &event::Event);
-}
-
-impl <H : EventHandler> EventHandler for Rc<RefCell<H>> {
-    fn handle_event(&mut self, event: &event::Event) {
-        self.borrow_mut().handle_event(event);
-    }
 }
 
 pub struct SimpleVideoOut {

--- a/src/emulator/io/mod.rs
+++ b/src/emulator/io/mod.rs
@@ -14,6 +14,12 @@ pub trait Input {
     fn register_event_handler(&mut self, handler: Box<dyn EventHandler>);
 }
 
+impl <T : Input> Input for Rc<RefCell<T>> {
+    fn register_event_handler(&mut self, handler: Box<dyn EventHandler>) {
+        self.borrow_mut().register_event_handler(handler);
+    }
+}
+
 pub trait Graphics {
     fn draw_screen(&mut self, pixel_data: &[u8]);
 }

--- a/src/emulator/io/sdl.rs
+++ b/src/emulator/io/sdl.rs
@@ -64,6 +64,8 @@ impl IO {
     }
 
     pub fn flip(&mut self) {
+        self.canvas.clear();
+        let _ = self.canvas.copy(&self.screen_texture, None, None);
         self.canvas.present();
     }
 
@@ -82,7 +84,6 @@ impl IO {
 impl Graphics for IO {
     fn draw_screen(&mut self, pixel_data: &[u8]) {
         let _ = self.screen_texture.update(None, pixel_data, 256 * 3);
-        let _ = self.canvas.copy(&self.screen_texture, None, None);
     }
 }
 

--- a/src/emulator/io/sdl.rs
+++ b/src/emulator/io/sdl.rs
@@ -1,12 +1,14 @@
 extern crate sdl2;
 
 use self::sdl2::event;
+use self::sdl2::keyboard::Keycode;
 use self::sdl2::pixels;
 use self::sdl2::render;
 use self::sdl2::video;
 
 use emulator::clock;
-use emulator::io::{EventHandler, Graphics, Input};
+use emulator::io::{Graphics, Input};
+use emulator::io::event::{Event, EventHandler, Key};
 
 const SCALE: u8 = 4;
 
@@ -66,8 +68,12 @@ impl IO {
     }
 
     pub fn process_event(&mut self, event: event::Event) {
-        for mut handler in self.event_handlers.iter_mut() {
-            handler.handle_event(&event);
+        let internal_event = convert_sdl_event_to_internal(event);
+
+        if let Some(e) = internal_event {
+            for mut handler in self.event_handlers.iter_mut() {
+                handler.handle_event(e);
+            }
         }
     }
 
@@ -96,3 +102,69 @@ impl clock::Ticker for IO {
     }
 }
 
+fn convert_sdl_event_to_internal(event: event::Event) -> Option<Event> {
+    match event {
+        event::Event::KeyDown { keycode, .. } => keycode
+            .and_then(|k| convert_sdl_keycode_to_internal(k))
+            .map(|k| Event::KeyDown(k)),
+        event::Event::KeyUp { keycode, .. } => keycode
+            .and_then(|k| convert_sdl_keycode_to_internal(k))
+            .map(|k| Event::KeyUp(k)),
+        _ => None,
+    }
+}
+
+fn convert_sdl_keycode_to_internal(keycode: Keycode) -> Option<Key> {
+    match keycode {
+        Keycode::A => Some(Key::A),
+        Keycode::B => Some(Key::B),
+        Keycode::C => Some(Key::C),
+        Keycode::D => Some(Key::D),
+        Keycode::E => Some(Key::E),
+        Keycode::F => Some(Key::F),
+        Keycode::G => Some(Key::G),
+        Keycode::H => Some(Key::H),
+        Keycode::I => Some(Key::I),
+        Keycode::J => Some(Key::J),
+        Keycode::K => Some(Key::K),
+        Keycode::L => Some(Key::L),
+        Keycode::M => Some(Key::M),
+        Keycode::N => Some(Key::N),
+        Keycode::O => Some(Key::O),
+        Keycode::P => Some(Key::P),
+        Keycode::Q => Some(Key::Q),
+        Keycode::S => Some(Key::S),
+        Keycode::T => Some(Key::T),
+        Keycode::U => Some(Key::U),
+        Keycode::V => Some(Key::V),
+        Keycode::W => Some(Key::W),
+        Keycode::X => Some(Key::X),
+        Keycode::Y => Some(Key::Y),
+        Keycode::Z => Some(Key::Z),
+
+        Keycode::Num0 => Some(Key::Num0),
+        Keycode::Num1 => Some(Key::Num1),
+        Keycode::Num2 => Some(Key::Num2),
+        Keycode::Num3 => Some(Key::Num3),
+        Keycode::Num4 => Some(Key::Num4),
+        Keycode::Num5 => Some(Key::Num5),
+        Keycode::Num6 => Some(Key::Num6),
+        Keycode::Num7 => Some(Key::Num7),
+        Keycode::Num8 => Some(Key::Num8),
+        Keycode::Num9 => Some(Key::Num9),
+        Keycode::Minus => Some(Key::Minus),
+        Keycode::Equals => Some(Key::Equals),
+
+        Keycode::Up => Some(Key::Up),
+        Keycode::Down => Some(Key::Down),
+        Keycode::Left => Some(Key::Left),
+        Keycode::Right => Some(Key::Right),
+
+        Keycode::Escape => Some(Key::Escape),
+        Keycode::Return => Some(Key::Return),
+        Keycode::Tab => Some(Key::Tab),
+        Keycode::Space => Some(Key::Space),
+
+        _ => None
+    }
+}

--- a/src/emulator/mappers.rs
+++ b/src/emulator/mappers.rs
@@ -189,10 +189,10 @@ impl memory::Mapper for MMC1 {
 
     fn mirror_mode(&self) -> MirrorMode {
         match self.control & 0x3 {
-            0 => MirrorMode::SINGLE_LOWER,
-            1 => MirrorMode::SINGLE_UPPER,
-            2 => MirrorMode::VERTICAL,
-            3 => MirrorMode::HORIZONTAL,
+            0 => MirrorMode::SingleLower,
+            1 => MirrorMode::SingleUpper,
+            2 => MirrorMode::Vertical,
+            3 => MirrorMode::Horizontal,
             _ => panic!("Unexpected mirror control: 0b{:b}", self.control),
         }
     }

--- a/src/emulator/memory.rs
+++ b/src/emulator/memory.rs
@@ -125,10 +125,10 @@ impl PPUMemory {
                 // Note that we don't just literally mirror the address horizontally/vertically.
                 // We need to make sure we always read from one of just 2 banks of memory.
                 let nt_bank = match self.mirrorer.mirror_mode() {
-                    MirrorMode::SINGLE_LOWER => 0,
-                    MirrorMode::SINGLE_UPPER => 1,
-                    MirrorMode::VERTICAL => (address & 0x0400) >> 10,
-                    MirrorMode::HORIZONTAL => (address & 0x0800) >> 11,
+                    MirrorMode::SingleLower => 0,
+                    MirrorMode::SingleUpper => 1,
+                    MirrorMode::Vertical => (address & 0x0400) >> 10,
+                    MirrorMode::Horizontal => (address & 0x0800) >> 11,
                 };
                 let mirrored_addr = 0x2000 | (nt_bank << 10) | (address & 0x03FF);
                 Some((&mut self.vram, mirrored_addr & 0x2FFF))

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -12,10 +12,14 @@ pub mod memory;
 pub mod ppu;
 pub mod util;
 
+#[cfg(test)]
+mod test;
+
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use emulator::controller::Button;
+use emulator::io::{EventHandler, Input};
 use emulator::io::sdl;
 use emulator::memory::ReadWriter;
 
@@ -51,7 +55,7 @@ impl NES {
 
         // Create graphics output module and PPU.
         let io = Rc::new(RefCell::new(sdl::IO::new()));
-        let output = sdl::Graphics::new(io.clone());
+        let output = io::SimpleVideoOut::new(io.clone());
 
         let ppu_memory = Box::new(memory::PPUMemory::new(
             Box::new(memory::ChrMapper::new(mapper.clone())),
@@ -247,7 +251,7 @@ impl Lifecycle {
     }
 }
 
-impl sdl::EventHandler for Lifecycle {
+impl EventHandler for Lifecycle {
     fn handle_event(&mut self, event: &event::Event) {
         match event {
             event::Event::KeyDown { keycode, .. } => {

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -132,7 +132,7 @@ impl NES {
             }
 
             if !self.lifecycle.borrow().speed_is_unlocked() {
-                self.clock.set_master_clock(NES_MASTER_CLOCK_TIME_PS);
+                self.clock.set_master_clock(self.lifecycle.borrow().clock_duration_ps());
             } else {
                 self.clock.set_master_clock(0);
             }
@@ -218,6 +218,7 @@ impl clock::Ticker for DMAController {
 pub struct Lifecycle {
     is_running: bool,
     unlock_speed: bool,
+    clock_duration_ps: u64,
 }
 
 impl Lifecycle {
@@ -225,6 +226,7 @@ impl Lifecycle {
         Lifecycle {
             is_running: false,
             unlock_speed: false,
+            clock_duration_ps: NES_MASTER_CLOCK_TIME_PS,
         }
     }
 
@@ -239,6 +241,10 @@ impl Lifecycle {
     pub fn speed_is_unlocked(&self) -> bool {
         self.unlock_speed
     }
+
+    pub fn clock_duration_ps(&self) -> u64 {
+        self.clock_duration_ps
+    }
 }
 
 impl sdl::EventHandler for Lifecycle {
@@ -248,6 +254,9 @@ impl sdl::EventHandler for Lifecycle {
                 match keycode {
                     Some(Keycode::Escape) => self.is_running = false,
                     Some(Keycode::Tab) => self.unlock_speed = !self.unlock_speed,
+                    Some(Keycode::Minus) => self.clock_duration_ps = self.clock_duration_ps.saturating_mul(2),
+                    Some(Keycode::Equals) => self.clock_duration_ps = self.clock_duration_ps / 2,
+                    Some(Keycode::Num0) => self.clock_duration_ps = NES_MASTER_CLOCK_TIME_PS,
                     _ => (),
                 };
             },

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -10,9 +10,6 @@ pub mod memory;
 pub mod ppu;
 pub mod util;
 
-#[cfg(test)]
-mod test;
-
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -1,6 +1,4 @@
 #![allow(dead_code)]
-extern crate sdl2;
-
 pub mod clock;
 pub mod components;
 pub mod controller;
@@ -19,12 +17,10 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use emulator::controller::Button;
-use emulator::io::{EventHandler, Input};
+use emulator::io::event::{Event, EventHandler, Key};
+use emulator::io::Input;
 use emulator::io::sdl;
 use emulator::memory::ReadWriter;
-
-use self::sdl2::event;
-use self::sdl2::keyboard::Keycode;
 
 // Timings (NTSC).
 // Master clock = 21.477272 MHz ~= 46.5ns per clock.
@@ -69,14 +65,14 @@ impl NES {
 
         // Create controllers.
         let joy1 = Rc::new(RefCell::new(controller::Controller::new([
-           (Keycode::Z, Button::A),
-           (Keycode::X, Button::B),
-           (Keycode::A, Button::Start),
-           (Keycode::S, Button::Select),
-           (Keycode::Up, Button::Up),
-           (Keycode::Down, Button::Down),
-           (Keycode::Left, Button::Left),
-           (Keycode::Right, Button::Right),
+           (Key::Z, Button::A),
+           (Key::X, Button::B),
+           (Key::A, Button::Start),
+           (Key::S, Button::Select),
+           (Key::Up, Button::Up),
+           (Key::Down, Button::Down),
+           (Key::Left, Button::Left),
+           (Key::Right, Button::Right),
         ].iter().cloned().collect())));
 
         let joy2 = Rc::new(RefCell::new(controller::Controller::new([
@@ -252,15 +248,15 @@ impl Lifecycle {
 }
 
 impl EventHandler for Lifecycle {
-    fn handle_event(&mut self, event: &event::Event) {
+    fn handle_event(&mut self, event: Event) {
         match event {
-            event::Event::KeyDown { keycode, .. } => {
-                match keycode {
-                    Some(Keycode::Escape) => self.is_running = false,
-                    Some(Keycode::Tab) => self.unlock_speed = !self.unlock_speed,
-                    Some(Keycode::Minus) => self.clock_duration_ps = self.clock_duration_ps.saturating_mul(2),
-                    Some(Keycode::Equals) => self.clock_duration_ps = self.clock_duration_ps / 2,
-                    Some(Keycode::Num0) => self.clock_duration_ps = NES_MASTER_CLOCK_TIME_PS,
+            Event::KeyDown(key) => {
+                match key {
+                    Key::Escape => self.is_running = false,
+                    Key::Tab => self.unlock_speed = !self.unlock_speed,
+                    Key::Minus => self.clock_duration_ps = self.clock_duration_ps.saturating_mul(2),
+                    Key::Equals => self.clock_duration_ps = self.clock_duration_ps / 2,
+                    Key::Num0 => self.clock_duration_ps = NES_MASTER_CLOCK_TIME_PS,
                     _ => (),
                 };
             },

--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -46,10 +46,10 @@ pub trait VideoOut {
 
 #[derive(Clone, Copy)]
 pub enum MirrorMode {
-    SINGLE_LOWER,
-    SINGLE_UPPER,
-    VERTICAL,
-    HORIZONTAL,
+    SingleLower,
+    SingleUpper,
+    Vertical,
+    Horizontal,
 }
 
 pub trait Mirrorer {

--- a/src/emulator/ppu/test/background.rs
+++ b/src/emulator/ppu/test/background.rs
@@ -33,29 +33,3 @@ fn test_render_simple_background() {
         ppu.tick();
     }
 }
-
-#[test]
-#[ignore]
-fn test_render_simple_background_sdl() {
-    // We're going to render a background tiled with a single tile.
-
-    // Firstly, create the PPU.
-    let io = sdl::IO::new();
-    let output = sdl::Graphics::new(Rc::new(RefCell::new(io)));
-    let mut ppu = new_ppu(Box::new(output));
-
-    // Load the X tile into the first position in pattern table 1.
-    load_data_into_vram(&mut ppu, 0x0000, &data::TILE_X);
-
-    // Fill the first nametable with this tile.
-    // Actually don't need to do anything, since 0 is the correct value.
-    
-    // PPUMASK.  Enable background only.
-    ppu.write(0x2001, 0b0000_1010);
-
-   
-    // Tick forward the PPU 89342 cycles (one frame).
-    for _ in 0..40000000 {
-        ppu.tick();
-    }
-}

--- a/src/emulator/ppu/test/background.rs
+++ b/src/emulator/ppu/test/background.rs
@@ -1,14 +1,9 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use emulator::clock::Ticker;
 use emulator::memory::Writer;
 use emulator::ppu::test::data;
 use emulator::ppu::test::load_data_into_vram;
 use emulator::ppu::test::new_ppu;
 use emulator::ppu::test::ImageCapture;
-
-use emulator::io::sdl;
 
 #[test]
 fn test_render_simple_background() {


### PR DESCRIPTION
- Refactor IO to allow us to pass in dummy IO modules in tests.
- Refactor Clock to not include any real-time timing.  That's handled outside now and should make testing easier.  It also means we now render the screen and process input at 30fps regardless of how fast the emulator is running.  This makes running in slow-mo much more responsive.
- Fix some bugs with Sprite 0-hit.