### PR TITLE
Dump CPU trace on panic.

### DIFF
--- a/src/bin/nes.rs
+++ b/src/bin/nes.rs
@@ -144,10 +144,3 @@ fn main_loop(controller: Rc<RefCell<Controller>>, compositor: &mut Compositor, a
     }
 }
 
-fn debug_print(nes: &mut NES, start: u16, len: u16) {
-    println!("CPU Memory starting from ${:X}", start);
-    for ix in 0 .. len {
-        print!("{:X} ", nes.cpu.borrow_mut().load_memory(start + ix));
-    }
-    println!("");
-}

--- a/src/bin/nes.rs
+++ b/src/bin/nes.rs
@@ -54,7 +54,20 @@ fn main() {
     event_bus.borrow_mut().register(Box::new(controller.clone()));
 
     // -- Run --
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        main_loop(controller.clone(), &mut compositor, &mut audio_queue, &mut input);
+    }));
 
+    match res {
+        Ok(_) => (),
+        Err(_) => {
+            controller.borrow_mut().dump_trace();
+            println!("Panic in main loop.  Exiting.");
+        },
+    }
+}
+
+fn main_loop(controller: Rc<RefCell<Controller>>, compositor: &mut Compositor, audio_queue: &mut AudioQueue, input: &mut InputPump) {
     let started_instant = Instant::now();
     let frames_per_second = RENDER_FPS;
     let mut frame_start = started_instant;

--- a/src/ui/controller.rs
+++ b/src/ui/controller.rs
@@ -32,6 +32,8 @@ impl Controller {
 
     pub fn start(&mut self) {
         self.is_running = true;
+        self.is_tracing = true;
+        self.nes.cpu.borrow_mut().start_tracing();
     }
 
     pub fn target_hz(&self) -> u64 {
@@ -40,6 +42,18 @@ impl Controller {
 
     pub fn show_debug(&self) -> bool {
         self.show_debug
+    }
+
+    pub fn dump_trace(&mut self) {
+        if self.is_tracing {
+            println!("Flushing CPU trace buffer to ./cpu.trace");
+            let mut trace_file = match File::create("./cpu.trace") {
+                Err(_) => panic!("Couldn't open trace file"),
+                Ok(f) => f,
+            };
+
+            self.nes.cpu.borrow_mut().flush_trace(&mut trace_file);
+        }
     }
 }
 
@@ -60,13 +74,7 @@ impl EventHandler for Controller {
                         println!("CPU Tracing: {}", if self.is_tracing { "ON" } else { "OFF" });
                     },
                     Key::Return => {
-                        println!("Flushing CPU trace buffer to ./cpu.trace");
-                        let mut trace_file = match File::create("./cpu.trace") {
-                            Err(_) => panic!("Couldn't open trace file"),
-                            Ok(f) => f,
-                        };
-
-                        self.nes.cpu.borrow_mut().flush_trace(&mut trace_file);
+                        self.dump_trace();
                     }
                     Key::Backquote => self.show_debug = !self.show_debug,
                     Key::Num1 => self.target_hz = 0,  // Paused

--- a/src/ui/controller.rs
+++ b/src/ui/controller.rs
@@ -55,6 +55,14 @@ impl Controller {
             self.nes.cpu.borrow_mut().flush_trace(&mut trace_file);
         }
     }
+
+    pub fn debug_print(&mut self, start: u16, len: u16) {
+        println!("CPU Memory starting from ${:X}", start);
+        for ix in 0 .. len {
+            print!("{:02X} ", self.nes.cpu.borrow_mut().load_memory(start + ix));
+        }
+        println!("");
+    }
 }
 
 impl EventHandler for Controller {


### PR DESCRIPTION
If we're tracing and hit a panic, dump out the trace before exiting.
Turn on tracing by default since the perf impact is minimal.