### PR TITLE
Comfort features for different play speeds

### DIFF
--- a/src/bin/nes.rs
+++ b/src/bin/nes.rs
@@ -45,7 +45,7 @@ fn main() {
     let video = sdl_context.video().unwrap();
     let audio = sdl_context.audio().unwrap();
 
-    let controller = Rc::new(RefCell::new(Controller::new(nes)));
+    let controller = Rc::new(RefCell::new(Controller::new(nes, video_output.clone())));
     let mut compositor = Compositor::new(video, video_output.clone(), ppu_debug);
     let mut audio_queue = AudioQueue::new(audio, audio_output.clone());
     let mut input = InputPump::new(sdl_context.event_pump().unwrap(), event_bus.clone());

--- a/src/bin/nes.rs
+++ b/src/bin/nes.rs
@@ -45,7 +45,7 @@ fn main() {
     let video = sdl_context.video().unwrap();
     let audio = sdl_context.audio().unwrap();
 
-    let controller = Rc::new(RefCell::new(Controller::new(nes, video_output.clone())));
+    let controller = Rc::new(RefCell::new(Controller::new(nes, video_output.clone(), audio_output.clone())));
     let mut compositor = Compositor::new(video, video_output.clone(), ppu_debug);
     let mut audio_queue = AudioQueue::new(audio, audio_output.clone());
     let mut input = InputPump::new(sdl_context.event_pump().unwrap(), event_bus.clone());

--- a/src/emulator/io/mod.rs
+++ b/src/emulator/io/mod.rs
@@ -71,6 +71,7 @@ pub struct SimpleAudioOut {
     low_pass_filter: LowPassFilter,
     high_pass_filter_1: HighPassFilter,
     high_pass_filter_2: HighPassFilter,
+    enabled: bool,
 }
 
 impl SimpleAudioOut {
@@ -306,11 +307,12 @@ impl SimpleAudioOut {
             low_pass_filter: LowPassFilter::new(35_000.0, SimpleAudioOut::APU_CLOCK),
             high_pass_filter_1: HighPassFilter::new(440.0, sample_rate),
             high_pass_filter_2: HighPassFilter::new(90.0, sample_rate),
+            enabled: true,
         }
     }
 
     pub fn consume<F : FnOnce(&[f32]) -> ()>(&mut self, num_samples: usize, consume: F) {
-        if self.buffer.len() == 0 || num_samples == 0 {
+        if self.buffer.len() == 0 || num_samples == 0 || !self.enabled {
             return;
         }
 
@@ -333,6 +335,10 @@ impl SimpleAudioOut {
         
         consume(&buf);
         self.buffer.clear();
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
     }
 
     fn queue_sample(&mut self, sample: f32) {

--- a/src/ui/compositor.rs
+++ b/src/ui/compositor.rs
@@ -37,6 +37,7 @@ impl Compositor {
 
         let canvas = main_window.into_canvas()
             .accelerated()
+            .present_vsync()
             .build()
             .unwrap();
 

--- a/src/ui/controller.rs
+++ b/src/ui/controller.rs
@@ -2,13 +2,14 @@ use std::cell::RefCell;
 use std::fs::File;
 use std::rc::Rc;
 
-use emulator::io::SimpleVideoOut;
+use emulator::io::{SimpleAudioOut, SimpleVideoOut};
 use emulator::io::event::{Event, EventHandler, Key};
 use emulator::{NES, NES_MASTER_CLOCK_HZ};
 
 pub struct Controller {
     nes: NES,
-    output: Rc<RefCell<SimpleVideoOut>>,
+    video_output: Rc<RefCell<SimpleVideoOut>>,
+    audio_output: Rc<RefCell<SimpleAudioOut>>,
     is_running: bool,
     is_tracing: bool,
     target_hz: u64,
@@ -16,10 +17,13 @@ pub struct Controller {
 }
 
 impl Controller {
-    pub fn new(nes: NES, output: Rc<RefCell<SimpleVideoOut>>) -> Controller {
+    pub fn new(nes: NES,
+               video_output: Rc<RefCell<SimpleVideoOut>>,
+               audio_output: Rc<RefCell<SimpleAudioOut>>) -> Controller {
         Controller {
             nes,
-            output,
+            video_output,
+            audio_output,
             is_running: false,
             is_tracing: false,
             target_hz: NES_MASTER_CLOCK_HZ,
@@ -41,7 +45,8 @@ impl Controller {
 
     pub fn set_target_hz(&mut self, hz: u64) {
         self.target_hz = hz;
-        self.output.borrow_mut().set_double_buffering(hz > 200_000);
+        self.video_output.borrow_mut().set_double_buffering(hz > 200_000);
+        self.audio_output.borrow_mut().set_enabled(hz >= 10_000_000 && hz <= 50_000_000);
     }
 
     pub fn target_hz(&self) -> u64 {


### PR DESCRIPTION
- Double buffer video unless running very slowly (where you would want to see individual scanlines render)
- Disable audio when running very fast or very slow