### PR TITLE
Fix sprites never rendering at y=0

### DIFF
--- a/src/emulator/ppu/mod.rs
+++ b/src/emulator/ppu/mod.rs
@@ -506,7 +506,7 @@ impl PPU {
         }
 
         let sprite_height = if self.ppuctrl.is_set(flags::PPUCTRL::H) { 16 } else { 8 };
-        let min_y = self.scanline.saturating_sub(sprite_height) + 1;
+        let min_y = self.scanline.saturating_sub(sprite_height - 1);
         let max_y = self.scanline;
 
         match self.sprite_eval_phase {


### PR DESCRIPTION
Fixes #19 

![image](https://user-images.githubusercontent.com/3620166/48211639-3f973b80-e3bd-11e8-8a72-a6dc3bd7bb55.png)

Due to the (lack of) overflow on this subtraction, sprites with y=0 would never render.  This caused the sprite 0-hit in the top-left of the Indiana Jones title screen to not trigger, which apparently causes a cascade of hilarity that breaks the game entirely.

Note that this title screen still has a glitch along the right-hand side.  I think it's because our CPU isn't cycle-accurate, so we might write the update to the palette 2-3 CPU cycles early, which could be as much as 9 pixels, which is about what we see here.