### PR TITLE
Add AxROM mapper

### DIFF
--- a/src/emulator/mappers/mod.rs
+++ b/src/emulator/mappers/mod.rs
@@ -15,3 +15,7 @@ pub use self::cnrom::CNROM;
 // #4 MMC1
 mod mmc1;
 pub use self::mmc1::MMC1;
+
+// #7 AxROM
+mod axrom;
+pub use self::axrom::AXROM;

--- a/src/emulator/mod.rs
+++ b/src/emulator/mod.rs
@@ -154,6 +154,7 @@ impl NES {
             1 => Rc::new(RefCell::new(mappers::MMC1::new(prg_rom, chr_rom))),
             2 => Rc::new(RefCell::new(mappers::UXROM::new(prg_rom, chr_rom, mirror_mode))),
             3 => Rc::new(RefCell::new(mappers::CNROM::new(prg_rom, chr_rom, mirror_mode))),
+            7 => Rc::new(RefCell::new(mappers::AXROM::new(prg_rom, chr_rom))),
             _ => panic!("Unknown mapper: {}", rom.mapper_number()),
         }
     }


### PR DESCRIPTION
Battletoads hangs on startup.  I kind of doubt that's the mapper's fault though.
Marble madness works fine:
![image](https://user-images.githubusercontent.com/3620166/48302051-76df2700-e53a-11e8-9ad3-638edb9697b0.png)
